### PR TITLE
Deploying Service Requires it to be Shrinkwrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ This process must be completed for each environment that the service is to be de
 
 Until such time as this is complete, the health monitoring service will only display the above instructions. Once complete the service can be used to monitor back end systems.
 
+## Deploying on 3.11.1 Workaround
+
+Issue: Dependencies are broken and the service does not deploy, it needs to be shrinkwrapped.
+
+Workaround:
+ * Create the new service.
+ * It will fail to deploy.
+ * Clone the code locally.
+ * npm install (using 0.10.30 nvm)
+ * npm shrinkwrap
+ * git add npm-shrinkwrap.json
+ * git commit -am 'adding shrinkwrap'
+ * git push origin master
+ * Deploy with clean stage
+
 
 ## Local Development
 For local development, the default value for the MongoDB connection string is defined in the Gruntfile.js as `mongodb://127.0.0.1/FH_LOCAL`. This makes use of the standard MongoDB used by $fh.db(). It requires that MongoDB is installed locally and that the FH_LOCAL database is available.


### PR DESCRIPTION
Deploying Service Requires it to be Shrinkwrapped locally first. Updating the readme to indicated this.
