### PR TITLE
RHMAP-12438 The search field by mongodb query filter doesn't work in the "Status Monitor Service" MBaaS page

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ For more information about how to use this service go to Documentation page `/#d
 ## Local Development
 For local development, the default value for the MongoDB connection string is defined in the Gruntfile.js as `mongodb://127.0.0.1/FH_LOCAL`. This makes use of the standard MongoDB used by $fh.db(). It requires that MongoDB is installed locally and that the FH_LOCAL database is available.
 
+### To Run
+
+* $npm install -g grunt-cli
+* $npm install
+* $grunt serve
+* Go to : `http://127.0.0.1:8001/`
 
 ## Grunt Tasks 
 
@@ -76,3 +82,4 @@ start the node application with local env vars
 
 * FH_MONGODB_CONN_URL: mongodb connection string. used by mongo db driver to connec to a valid mongodb instance 
 * HTTP(S)
+* `FH_PORT` or `VCAP_APP_PORT`: Options to override the default port (8001).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ This process must be completed for each environment that the service is to be de
 
 Until such time as this is complete, the health monitoring service will only display the above instructions. Once complete the service can be used to monitor back end systems.
 
+## To add remote-end-points
+
+This feature is only available at `/admin`.
+
+To create a new check the 'add new' will then be enabled. Click on 'Add new' and then enter the following data:
+
+* Check Name: A name for your own reference
+* Description: A description for your own reference
+* Interval: How many minutes to wait between checks
+* Timeout: How long to allow the service to respond, before considering it disconnected
+* Record Rotation: How many days to store our logs of the responsiveness of the host
+* Check Type: If the service is a website choose 'http(s)' otherwise choose 'TCP'
+
+### TCP Options
+
+* Host: The host to connect to.
+* Port: The port to connect to.
+
+### HTTP(s) Options
+
+* Url: The URL of the website to connect to (e.g. http://feedhenry.com or https://feedhenry.com)
+* Method: GET or POST, pick whichever your application is expecting, if you're unsure, use GET
+* Send Body: This is not required, but in a POST request you can specify the POST data to send
+* Response Regexp Check: This is not required, you can enter a regex in here to verify the response is as expected.
+
+For more information about how to use this service go to Documentation page `/#documentation`. 
 
 ## Local Development
 For local development, the default value for the MongoDB connection string is defined in the Gruntfile.js as `mongodb://127.0.0.1/FH_LOCAL`. This makes use of the standard MongoDB used by $fh.db(). It requires that MongoDB is installed locally and that the FH_LOCAL database is available.

--- a/client/index.html
+++ b/client/index.html
@@ -1341,7 +1341,7 @@ app.tmpl=(function(module){
         url+=$.param(obj);
         window.location=url;
       }catch(e){
-        app.msg.alert("Invalid query string. Check MongoDb query reference.");
+        app.msg.alert("Invalid MongoDB query filter parameter.  Query Example: {'isSuccessful' : false )}");
       }
     }
   });
@@ -1565,7 +1565,7 @@ app.tmpl=(function(module){
 <td> <%= typeof (failReason)!="undefined"?failReason:"N/A" %> </td>
 </script>
 <script type="text/template" id="tmpl_runlist"><div class="page">
-  <h3><small><a href="#">Home</a></small>  Result Log: <%= checkName %><small> Query: <input id="queryStr" placeholder="Mongodb Query String" style="width:600px"/><button type="button" id="queryBtn">Go</button></small></h3>
+  <h3><small><a href="#">Home</a></small>  Result Log: <%= checkName %><small> Query: <input id="queryStr" placeholder="MongoDB Query Filter Parameter" style="width:600px"/><button type="button" id="queryBtn">Go</button></small></h3>
   <table id="run_list" class="table table-striped">
     <tr>
       <th></th>

--- a/static/client/app/views/runTable.js
+++ b/static/client/app/views/runTable.js
@@ -58,7 +58,7 @@
         url+=$.param(obj);
         window.location=url;
       }catch(e){
-        app.msg.alert("Invalid query string. Check MongoDb query reference.");
+        app.msg.alert("Invalid MongoDB query filter parameter.  Query Example: {'isSuccessful' : false )}");
       }
     }
   });

--- a/static/client/templates/tmpl_monitorlist.html
+++ b/static/client/templates/tmpl_monitorlist.html
@@ -12,7 +12,7 @@
       </div>
       <div class="collapse navbar-collapse">
         <button class="navbar-btn btn btn-primary" id="checkUrlBtn">Summary Url</button>
-        Filter tests: <input type='text' id="filterText" />
+        Filter tests: <input type='text' id="filterText" placeholder="Search by name" />
         <ul class="nav navbar-nav">
           <li></li>
         </ul>

--- a/static/client/templates/tmpl_runlist.html
+++ b/static/client/templates/tmpl_runlist.html
@@ -1,5 +1,15 @@
 <div class="page">
-  <h3><small><a href="#">Home</a></small>  Result Log: <%= checkName %><small> Query: <input id="queryStr" placeholder="Mongodb Query String" style="width:600px"/><button type="button" id="queryBtn">Go</button></small></h3>
+
+    <table id="label" class="table table-striped">
+        <tr>
+            <th><a href="#">Home</a></th>
+            <th> Result Log: <%= checkName %></th>
+            <th>Query: <input id="queryStr" placeholder="MongoDB Query Filter Parameter" style="width:80%"/></th>
+            <th><button type="button" id="queryBtn">Go</button></th>
+        </tr>
+    </table>
+
+
   <table id="run_list" class="table table-striped">
     <tr>
       <th></th>


### PR DESCRIPTION
RHMAP-12438 - The search field by mongodb query filter doesn't work in the "Status Monitor Service" MBaaS page

The real problem was the name (placeholder) which was given the idea to do a filter as db.collection.finddb